### PR TITLE
Ignorando a pasta .git ao deletar os arquivos .idx

### DIFF
--- a/makefile
+++ b/makefile
@@ -50,7 +50,7 @@ clean:
 	@find . -type f -iname "*.glo" -delete
 	@find . -type f -iname "*.gls" -delete
 	@find . -type f -iname "*.glsdefs" -delete
-	@find . -type f -iname "*.idx" -delete
+	@find . -type f -iname "*.idx" ! -path "./.git/*" -delete
 	@find . -type f -iname "*.ilg" -delete
 	@find . -type f -iname "*.ind" -delete
 	@find . -type f -iname "*.ist" -delete


### PR DESCRIPTION
O Git possui arquivos .idx na pasta .git. 

![image](https://user-images.githubusercontent.com/2946985/27617973-f98b63a2-5b8f-11e7-97e5-89fd1285be98.png)

O clean do Makefile acaba corrompendo o repositório local do Git